### PR TITLE
Fixes error when embedding the script into a page.

### DIFF
--- a/jquery.ba-hashchange.js
+++ b/jquery.ba-hashchange.js
@@ -370,7 +370,7 @@
           iframe_doc.open();
           
           // Set document.domain for the Iframe document as well, if necessary.
-          domain && iframe_doc.write( '<script>document.domain="' + domain + '"</script>' );
+          domain && iframe_doc.write( '<script>document.domain="' + domain + '"<\/script>' );
           
           iframe_doc.close();
           


### PR DESCRIPTION
This script works well when including it into an external file, but it fails when embedding it in the same file. This fixes it by always escaping it, which will work in embedded and external documents.

The reason why it fails is because when you embed this script into the same page with "<script> all script goes here</script>", browsers will treat that element as a closing script tag causing the rest of the code to be treated as text.

It is good practice to always escape "</script>"  tags when using them in JavaScript.
