### PR TITLE
Replaced $.browser property in order to work in jQuery 1.9+

### DIFF
--- a/jquery.ba-hashchange.js
+++ b/jquery.ba-hashchange.js
@@ -297,7 +297,7 @@
     // vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
     // vvvvvvvvvvvvvvvvvvv REMOVE IF NOT SUPPORTING IE6/7/8 vvvvvvvvvvvvvvvvvvv
     // vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
-    $.browser.msie && !supports_onhashchange && (function(){
+    navigator.userAgent.match(/msie [6,7,8]/i) && !supports_onhashchange && (function(){
       // Not only do IE6/7 need the "magical" Iframe treatment, but so does IE8
       // when running in "IE7 compatibility" mode.
       


### PR DESCRIPTION
Replaced $.browser property in order to work in jQuery 1.9+. Used navigator.userAgent instead.
