### PR TITLE
Replaced $.browser as deprecated in jQuery 1.9

### DIFF
--- a/jquery.ba-hashchange.js
+++ b/jquery.ba-hashchange.js
@@ -297,7 +297,9 @@
     // vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
     // vvvvvvvvvvvvvvvvvvv REMOVE IF NOT SUPPORTING IE6/7/8 vvvvvvvvvvvvvvvvvvv
     // vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
-    $.browser.msie && !supports_onhashchange && (function(){
+		// Fix for $.browser deprecated in jQuery 1.10
+		var msie = /MSIE/.test(navigator.userAgent);
+		msie && !supports_onhashchange && (function(){
       // Not only do IE6/7 need the "magical" Iframe treatment, but so does IE8
       // when running in "IE7 compatibility" mode.
       


### PR DESCRIPTION
I need to use this with jQuery 1.10, and $.browser was deprecated in jQuery 1.9.

Replaced $.browser.msie with /MSIE/.test(navigator.userAgent)
